### PR TITLE
changes to support Geant4.11.4

### DIFF
--- a/artg4tk/lists/ArParticleHPCaptureFS.cc
+++ b/artg4tk/lists/ArParticleHPCaptureFS.cc
@@ -305,8 +305,13 @@ void
 ArParticleHPCaptureFS::Init(G4double A,
                             G4double Z,
                             G4int M,
+#if G4VERSION_NUMBER >= 1130
+                            const G4String& dirName,
+                            const G4String&,
+#else
                             G4String& dirName,
                             G4String&,
+#endif
                             G4ParticleDefinition*)
 {
 

--- a/artg4tk/lists/ArParticleHPCaptureFS.hh
+++ b/artg4tk/lists/ArParticleHPCaptureFS.hh
@@ -19,6 +19,7 @@
 // -- artg4tk includes
 #include "artg4tk/lists/ArCaptureGammas.hh"
 
+#include "Geant4/G4Version.hh"
 #include "Geant4/G4HadFinalState.hh"
 #include "Geant4/G4HadProjectile.hh"
 #include "Geant4/G4ParticleHPEnAngCorrelation.hh"
@@ -40,8 +41,13 @@ public:
   void Init(G4double A,
             G4double Z,
             G4int M,
+#if G4VERSION_NUMBER >= 1130
+            const G4String& dirName,
+            const G4String& aFSType,
+#else
             G4String& dirName,
             G4String& aFSType,
+#endif
             G4ParticleDefinition*) override;
   G4HadFinalState* ApplyYourself(const G4HadProjectile& theTrack) override;
   G4ParticleHPFinalState*

--- a/artg4tk/lists/MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias.cc
+++ b/artg4tk/lists/MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias.cc
@@ -104,8 +104,14 @@ MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias::CreateModels()
   tpdata->theHyperon = new G4HyperonFTFPBuilder;
 
   tpdata->theAntiBaryon = new G4AntiBarionBuilder;
+#if G4VERSION_NUMBER >= 1140
+  // tpdata->theFTFPAntiBaryon = new G4FTFPAntiBarionBuilder;
+  tpdata->theQGSPAntiBaryon = new G4QGSPAntiBarionBuilder(quasiElasticQGS);
+  // tpdata->theQGSPAntiBaryon->RegisterMe(tpdata->theQGSPAntiBaryon);
+#else
   tpdata->theAntiBaryon->RegisterMe(tpdata->theFTFPAntiBaryon =
-                                      new G4FTFPAntiBarionBuilder(quasiElasticFTF));
+                                    new G4FTFPAntiBarionBuilder(quasiElasticFTF));
+#endif
 }
 
 MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias::~MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias()
@@ -126,7 +132,12 @@ MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias::~MyG4HadronPhysicsQGSP_BERT_HP_Neut
   delete tpdata->theQGSPPro;
   delete tpdata->theFTFPPro;
   delete tpdata->thePro;
+#if G4VERSION_NUMBER >= 1140
+  //delete tpdata->theFTFPAntiBaryon;
+  delete tpdata->theQGSPAntiBaryon;
+#else
   delete tpdata->theFTFPAntiBaryon;
+#endif
   delete tpdata->theAntiBaryon;
   delete tpdata->theHyperon;
 
@@ -175,6 +186,9 @@ MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias::ConstructProcess()
 
   tpdata->theHyperon->Build();
   tpdata->theAntiBaryon->Build();
+#if G4VERSION_NUMBER >= 1140
+  tpdata->theQGSPAntiBaryon->Build();
+#endif
 
   // --- Neutrons ---
   G4HadronicProcess* capture = 0;

--- a/artg4tk/lists/MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias.hh
+++ b/artg4tk/lists/MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias.hh
@@ -1,6 +1,7 @@
 #ifndef MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias_h
 #define MyG4HadronPhysicsQGSP_BERT_HP_NeutronXSBias_h 1
 
+#include "G4Version.hh"
 #include "Geant4/G4ios.hh"
 #include "Geant4/globals.hh"
 
@@ -28,7 +29,11 @@
 
 // -- Other builders
 #include "Geant4/G4AntiBarionBuilder.hh"
+#if G4VERSION_NUMBER >= 1140
+#include "Geant4/G4QGSPAntiBarionBuilder.hh"
+#else
 #include "Geant4/G4FTFPAntiBarionBuilder.hh"
+#endif
 #include "Geant4/G4HyperonFTFPBuilder.hh"
 
 class G4ComponentGGHadronNucleusXsc;
@@ -68,7 +73,11 @@ private:
     G4HyperonFTFPBuilder* theHyperon;
 
     G4AntiBarionBuilder* theAntiBaryon;
+#if G4VERSION_NUMBER >= 1140
+    G4QGSPAntiBarionBuilder* theQGSPAntiBaryon;
+#else
     G4FTFPAntiBarionBuilder* theFTFPAntiBaryon;
+#endif
 
     G4ComponentGGHadronNucleusXsc* xsKaon;
     G4VCrossSectionDataSet* xsNeutronCaptureXS;

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -248,7 +248,7 @@ gdmldir	product_dir	gdml
 ####################################
 product		version		qual	flags		<table_format=2>
 art_root_io	v1_13_06	-
-geant4          v4_11_2_p02
+geant4          v4_11_4_p01
 cetmodules	v3_24_01	-	only_for_build
 end_product_list
 ####################################


### PR DESCRIPTION
Deal with interface const change in what ArParticleHPCaptureFS inherits from
Deal with the demise of Geant4 class G4FTFPAntiBarionBuilder which is currently broken
Update ups/product_deps from giant v4_11_2_p02 to v4_11_4_p01